### PR TITLE
Change user to non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,27 @@
 FROM openjdk:8u141-jre
+
 ENV MC_VERSION 3.10
 ENV MC_HOME /opt/hazelcast/mancenter
 ENV MANCENTER_DATA /data
-VOLUME ["/data"]
+ENV USER_NAME=hazelcast
+ENV USER_UID=10001
 
+# Prepare Management Center
 RUN mkdir -p $MC_HOME
+RUN mkdir -p $MANCENTER_DATA
 WORKDIR $MC_HOME
 ADD http://download.hazelcast.com/management-center/hazelcast-management-center-$MC_VERSION.zip $MC_HOME/mancenter.zip
 RUN unzip mancenter.zip
-### Start Hazelcast Management Center standalone server
 COPY start.sh .
 RUN chmod a+x start.sh
-CMD ["/bin/sh", "-c", "./start.sh"]
+
+### Configure user
+RUN useradd -l -u $USER_UID -r -g 0 -d $MC_HOME -s /sbin/nologin -c "${USER_UID} application user" $USER_NAME
+RUN chown -R $USER_UID:0 $MC_HOME $MANCENTER_DATA
+RUN chmod +x $MC_HOME/*.sh
+USER $USER_UID
+
+VOLUME ["/data"]
 EXPOSE 8080
+
+CMD ["/bin/sh", "-c", "./start.sh"]


### PR DESCRIPTION
Change user to non-root ('hazelcast' instead of 'root').

@emre-aydin , I tested some simple scenarios and it worked fine, but please think if there's anything in MC that requires root user (I don't think so, but just in case).

Background: OpenShift does not allow to run images as root user, so currently there is a separate image (hazelcast/management-center-openshift) that just change the user. Together with Mesut and Hasan, we came to the conclusion that it does not make sense to keep a separate repository, Docker image, just for that case. Also, in general, it makes more sense to run everything as non-root.