### PR TITLE
Upgrade to openjdk:11-jre-slim + move CMD to external file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ RUN curl -svf -o ${MC_HOME}/${MC_INSTALL_ZIP} \
 # Runtime environment variables
 ENV JAVA_OPTS_DEFAULT "-Dhazelcast.mancenter.home=${MC_DATA} -Djava.net.preferIPv4Stack=true"
 
+ENV MIN_HEAP_SIZE ""
+ENV MAX_HEAP_SIZE ""
+
 ENV JAVA_OPTS ""
 
 ADD files/mc-start.sh /mc-start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 
 ENV MC_VERSION 3.11.3
 ENV MC_HOME /opt/hazelcast/mancenter
@@ -24,7 +24,7 @@ RUN apt-get update \
 # Comment out assistive_technologies configuration
 # Without commenting this out, a "headless" Java installation causes a traceback on Management Center start
 # Ref: https://askubuntu.com/a/723503
-RUN sed -i -e 's/^assistive_technologies=/#assistive_technologies=/g' /etc/java-8-openjdk/accessibility.properties
+RUN sed -i -e 's/^assistive_technologies=/#assistive_technologies=/g' /etc/java-11-openjdk/accessibility.properties
 
 # chmod allows running container as non-root with `docker run --user` option
 RUN mkdir -p ${MC_HOME} ${MC_DATA} \
@@ -41,25 +41,13 @@ RUN curl -svf -o ${MC_HOME}/${MC_INSTALL_ZIP} \
 # Runtime environment variables
 ENV JAVA_OPTS_DEFAULT "-Dhazelcast.mancenter.home=${MC_DATA} -Djava.net.preferIPv4Stack=true"
 
-ENV MIN_HEAP_SIZE ""
-ENV MAX_HEAP_SIZE ""
-
 ENV JAVA_OPTS ""
 
+ADD files/mc-start.sh /mc-start.sh
+
 VOLUME ["${MC_DATA}"]
-EXPOSE 8080
-EXPOSE 8443
+EXPOSE ${MC_HTTP_PORT}
+EXPOSE ${MC_HTTPS_PORT}
 
 # Start Management Center
-CMD ["bash", "-c", "set -euo pipefail \
-      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
-      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
-      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
-      && echo \"########################################\" \
-      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
-      && echo \"# starting now....\" \
-      && echo \"########################################\" \
-      && set -x \
-      && exec java -server ${JAVA_OPTS} -jar ${MC_RUNTIME} \
-                ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_CONTEXT} \
-     "]
+CMD ["bash", "/mc-start.sh"]

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -7,6 +7,14 @@ else
     export JAVA_OPTS="${JAVA_OPTS_DEFAULT}"
 fi
 
+if [ -n "${MIN_HEAP_SIZE}" ]; then
+    export JAVA_OPTS="${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}"
+fi
+
+if [ -n "${MAX_HEAP_SIZE}" ]; then
+    export JAVA_OPTS="${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}"
+fi
+
 echo "########################################"
 echo "# JAVA_OPTS=${JAVA_OPTS}"
 echo "# starting now...."

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+if [ -n "${JAVA_OPTS}" ]; then
+    export JAVA_OPTS="${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}"
+else
+    export JAVA_OPTS="${JAVA_OPTS_DEFAULT}"
+fi
+
+echo "########################################"
+echo "# JAVA_OPTS=${JAVA_OPTS}"
+echo "# starting now...."
+echo "########################################"
+
+set -x
+exec java \
+    -server ${JAVA_OPTS} \
+    -jar ${MC_RUNTIME} \
+    ${MC_HTTP_PORT} \
+    ${MC_HTTPS_PORT} \
+    ${MC_CONTEXT}
+


### PR DESCRIPTION
Hello! I've got a PR here to migrate the management center to OpenJDK11 (in order to leverage the container awareness added in Java 10). Figured I'd share it, in case it was of some use to you.

If locking the version to Java 11 is problematic, I am happy to adjust the PR to allow the java version to be set with a build-time parameter.

Cheers!