### PR TITLE
Simplify directory structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ ENV MC_CONTEXT hazelcast-mancenter
 
 ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
 ARG MC_INSTALL_ZIP="${MC_INSTALL_NAME}.zip"
-ARG MC_INSTALL_DIR="${MC_HOME}/${MC_INSTALL_NAME}"
 ARG MC_INSTALL_WAR="hazelcast-mancenter-${MC_VERSION}.war"
 
-ENV MC_RUNTIME "${MC_INSTALL_DIR}/${MC_INSTALL_WAR}"
+ENV MC_RUNTIME "${MC_HOME}/${MC_INSTALL_WAR}"
 
 # Install curl to download management center
 RUN apt-get update \
@@ -36,7 +35,9 @@ RUN curl -svf -o ${MC_HOME}/${MC_INSTALL_ZIP} \
          -L http://download.hazelcast.com/management-center/${MC_INSTALL_ZIP} \
  && unzip ${MC_INSTALL_ZIP} \
       -x ${MC_INSTALL_NAME}/docs/* \
- && rm -rf ${MC_INSTALL_ZIP}
+ && rm -rf ${MC_INSTALL_ZIP} \
+ && mv ${MC_INSTALL_NAME}/* . \
+ && rm -rf ${MC_INSTALL_NAME}
 
 # Runtime environment variables
 ENV JAVA_OPTS_DEFAULT "-Dhazelcast.mancenter.home=${MC_DATA} -Djava.net.preferIPv4Stack=true"
@@ -46,7 +47,8 @@ ENV MAX_HEAP_SIZE ""
 
 ENV JAVA_OPTS ""
 
-ADD files/mc-start.sh /mc-start.sh
+COPY files/mc-start.sh /mc-start.sh
+RUN chmod +x /mc-start.sh
 
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT}

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -20,8 +20,10 @@ echo "# JAVA_OPTS=${JAVA_OPTS}"
 echo "# starting now...."
 echo "########################################"
 
+# --add-opens flag is required to prevent this issue: https://jira.spring.io/browse/SPR-15859
 set -x
 exec java \
+    --add-opens java.base/java.lang=ALL-UNNAMED \
     -server ${JAVA_OPTS} \
     -jar ${MC_RUNTIME} \
     ${MC_HTTP_PORT} \


### PR DESCRIPTION
* Now all files from MC .zip archive are located in `#{MC_HOME}` (previously it was `#{MC_HOME}/hazelcast-management-center-${MC_VERSION}`)
* Also fixes startup warnings from Spring (due to Java 11)