### PR TITLE
Fix MAX_HEAP_SIZE env var

### DIFF
--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -12,7 +12,7 @@ if [ -n "${MIN_HEAP_SIZE}" ]; then
 fi
 
 if [ -n "${MAX_HEAP_SIZE}" ]; then
-    export JAVA_OPTS="${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}"
+    export JAVA_OPTS="${JAVA_OPTS} -Xmx${MAX_HEAP_SIZE}"
 fi
 
 if [ -n "${MC_CLASSPATH}" ]; then


### PR DESCRIPTION
* `-Xms` was used instead of `-Xmx` for the `MAX_HEAP_SIZE` env var

Reported by @yozank 