### PR TITLE
Add health check endpoint support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV MC_DATA /data
 
 ENV MC_HTTP_PORT 8080
 ENV MC_HTTPS_PORT 8443
+ENV MC_HEALTH_CHECK_PORT 8081
 ENV MC_CONTEXT hazelcast-mancenter
 
 ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
@@ -50,6 +51,7 @@ RUN chmod +x /mc-start.sh
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT}
 EXPOSE ${MC_HTTPS_PORT}
+EXPOSE ${MC_HEALTH_CHECK_PORT}
 
 # Start Management Center
 CMD ["bash", "/mc-start.sh"]

--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ You can start the Management Center with an extra classpath entry (for example, 
 ```
 docker run -e MC_CLASSPATH='/path/to/your-extra.jar' -p 8080:8080 hazelcast/management-center
 ```
+
+## Enabling Health Check Endpoint
+
+When running the Management Center, you can enable the Health Check endpoint:
+
+```
+docker run -p 8080:8080 -p 8081:8081 -e JAVA_OPTS='-Dhazelcast.mc.healthCheck.enable=true' hazelcast/management-center:$MANAGEMENT_CENTER
+```
+
+This endpoint may be used in container-orchestraction systems, like Kubernetes. Refer to [the Management Center documentation](https://docs.hazelcast.org/docs/management-center/3.12.5/manual/html/index.html#enabling-health-check-endpoint) for more information.


### PR DESCRIPTION
* Closes #16
* As arithmetic operations with `ARG` or `ENV` in `Dockerfile`s are tricky, the health check port is exposed as an env var
* Also adds a readme section