### PR TITLE
Change to multi-arch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:11-jre-slim-sid
 
 ENV MC_VERSION 4.0.2
 ENV MC_HOME /opt/hazelcast/management-center


### PR DESCRIPTION
We plan to build mutli-arch images from Hazelcast (and Management Center). That is mainly targeted to IBM and their "IBM on Z Linux" and PowerLinux. 

This PR changes the base image to the similar one, but which has multi-arch support.

The output Management Center image size increases from `148.05 MB` to `184.6MB`. If you think it's a big deal, then we can discuss how to approach it differently.

Related Hazelcast PR: https://github.com/hazelcast/hazelcast-docker/pull/142