### PR TITLE
Add Jenkinsfile for the release automation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:11-jre-slim-sid
 
 ENV MC_VERSION 4.0.2
 ENV MC_HOME /opt/hazelcast/management-center

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,32 @@
+pipeline {
+    agent {
+        node {
+            label 'multi-arch-docker-release'
+            customWorkspace "${JOB_NAME}/${BUILD_NUMBER}"
+        }
+    }
+
+    parameters {
+        string(name: 'MANAGEMENT_CENTER_DOCKER_TAG', description: 'Management Center Docker Tag')
+    }
+
+    stages {
+        stage('Log into Docker Hub') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'devopshazelcast-dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    sh "docker login --username ${USERNAME} --password ${PASSWORD}"
+                }
+            }
+        }
+        stage('Build and push "hazelcast/management-center" image') {
+            steps {
+                dir("./") {
+                    script {
+                        sh "docker buildx build -t hazelcast/management-center:${MANAGEMENT_CENTER_DOCKER_TAG} --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x . --push"
+                    }
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Docker image release automation.

Similar to the PR sent for Hazelcast: https://github.com/hazelcast/hazelcast-docker/pull/143

Before the images were built by the Docker Hub automation, but it does not support multi-arch builds, so we need to automate it ourselves.

- I've already turned-off [Docker Hub Automation](https://hub.docker.com/repository/docker/hazelcast/management-center/builds) (so the images won't be built after every tag pushed to the repository)
- @yuraku @emre-aydin could I ask you to add a trigger for the [management-center-docker-release pipeline](http://jenkins.hazelcast.com/view/Plugin%20Release/job/management-center-docker-release/)? It should be triggered after you released a new version of Management Center and after you pushed a new tag to hazelcast/management-center-docker repository. The pipeline has one parameter MANAGEMENT_CENTER_DOCKER_TAG and it should be the Management Center version (like the tag name, but without `v` at the beginning), for example: `4.0.2`
- I'll add a similar pipeline for management-center-openshift, but we need first to solve the issue with publishing multi-arch images to Red Hat Registry, so no changes there for now
- I'll extend this Jenkinsfile with tests and failure mail notifications in a separate PR. For now, I'd like to have exactly what we had with the use of Docker Hub automation