### PR TITLE
Multi-arch PR builders and release builds

### DIFF
--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -1,0 +1,28 @@
+name: Build/Push Management Center latest image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: v0.4.1
+          qemu-version: 4.2.0-7
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push Management Center image
+        run: |
+          docker buildx build --push \
+            --tag hazelcast/management-center:latest \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x .

--- a/.github/workflows/latest_image_push.yml
+++ b/.github/workflows/latest_image_push.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -1,0 +1,35 @@
+name: Build/Push Management Center image
+
+on:
+  create:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set Release Version
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
+      - name: Print Release Version
+        run: |
+          echo ${{ env.RELEASE_VERSION }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: v0.4.1
+          qemu-version: 4.2.0-7
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build/Push Management Center image
+        run: |
+          docker buildx build --push \
+            --tag hazelcast/management-center:${{ env.RELEASE_VERSION }} \
+            --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x .

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,3 @@ script:
   - |
     MC_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${MC_IMAGE}-container)
     nc -z -v $MC_IP 8080
-
-# notifications:
-#   email:
-#     recipients:
-#       - hasan@hazelcast.com
-#       - rafal@hazelast.com
-#       - emre@hazelcast.com
-#     on_success: never
-#     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: minimal
+
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
+
+os: linux
+
+services:
+  - docker
+
+env:
+  - MC_IMAGE=management-center
+
+install:
+  - docker build -t $MC_IMAGE .
+
+script:
+  - docker images
+  - |
+    docker run --name ${MC_IMAGE}-container -d --rm -p 8080:8080 $MC_IMAGE
+    sleep 20
+    docker logs ${MC_IMAGE}-container
+  - |
+    MC_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${MC_IMAGE}-container)
+    nc -z -v $MC_IP 8080
+
+# notifications:
+#   email:
+#     recipients:
+#       - hasan@hazelcast.com
+#       - rafal@hazelast.com
+#       - emre@hazelcast.com
+#     on_success: never
+#     on_failure: always


### PR DESCRIPTION
- [x] Travis CI multi-arch PR builder
- [x] Github Action for latest tag at DockerHub
- [x] Github Action for release tag at DockerHub

Sample Travis CI PR builder logs and result:
https://travis-ci.org/github/hasancelik/management-center-docker/builds/692037465

You can check tags and Github actions build logs that are created by my test setup:
https://hub.docker.com/r/hasancelik/management-center/tags
https://github.com/hasancelik/management-center-docker/runs/715682698?check_suite_focus=true
https://github.com/hasancelik/management-center-docker/runs/715682698?check_suite_focus=true

IMDG side counterpart PRs:
https://github.com/hazelcast/hazelcast-docker/pull/145
https://github.com/hazelcast/hazelcast-docker/pull/146