### PR TITLE
added --lenient flag into admin user creation command

### DIFF
--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -38,7 +38,7 @@ fi
 
 if [ -n "${MC_ADMIN_USER}" ] && [ -n "${MC_ADMIN_PASSWORD}" ]; then
   echo "Creating admin user"
-  source ./mc-conf.sh user create -H=${MC_DATA} -n=${MC_ADMIN_USER} -p=${MC_ADMIN_PASSWORD} -r=admin
+  source ./mc-conf.sh user create --lenient=true -H=${MC_DATA} -n=${MC_ADMIN_USER} -p=${MC_ADMIN_PASSWORD} -r=admin
   if [ $? -eq 0 ]; then
     echo "User created successfully"
   else


### PR DESCRIPTION
If you restart MC pod that has `adminCredentialsSecretName` configuration, restarted pod becomes unavailable(`CrashLoopBackOff`) due to below error:
```
ERROR: The user with username 'hasan' already exists.
```

To convert it into `Warning` and prevent `CrashLoopBackOff` at MC pod, we need to enable `--lenient` flag:
```
WARNING: The user with username 'hasan' already exists.
```

resolves https://github.com/hazelcast/charts/issues/158