### PR TITLE
Add LOGGING_LEVEL environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
 FROM openjdk:11.0.7-jre-slim
 
 ARG MC_VERSION=4.2020.08
-ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
-ARG MC_INSTALL_ZIP="${MC_INSTALL_NAME}.zip"
-ARG MC_INSTALL_JAR="hazelcast-management-center-${MC_VERSION}.jar"
+ARG MC_JAR="hazelcast-management-center-${MC_VERSION}.jar"
+ARG MC_JAR_LOCATION="https://download.hazelcast.com/management-center/${MC_JAR}"
 
 # Runtime constants / variables
 ENV MC_HOME="/opt/hazelcast/management-center" \
-    MC_INSTALL_NAME="${MC_INSTALL_NAME}" \
-    MC_INSTALL_ZIP="${MC_INSTALL_ZIP}" \
-    MC_INSTALL_JAR="${MC_INSTALL_JAR}" \
+    MC_JAR="${MC_JAR}" \
     MC_DATA="/data" \
     MC_HTTP_PORT="8080" \
     MC_HTTPS_PORT="8443" \
@@ -28,22 +25,15 @@ ENV MC_HOME="/opt/hazelcast/management-center" \
 
 RUN echo "Installing new APT packages" \
     && apt-get update \
-    && apt-get install --no-install-recommends --yes curl unzip \
+    && apt-get install --no-install-recommends --yes curl \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p ${MC_HOME} ${MC_DATA} \
     && echo "Granting full access to ${MC_HOME} and ${MC_DATA} to allow running" \
         "container as non-root with \"docker run --user\" option" \
     && chmod a+rwx ${MC_HOME} ${MC_DATA} \
     && echo "Downloading Hazelcast Management Center" \
-    && curl --silent -o "${MC_HOME}/${MC_INSTALL_ZIP}" \
-        -L "http://download.hazelcast.com/management-center/${MC_INSTALL_ZIP}" \
-    && cd ${MC_HOME} \
-    && unzip ${MC_INSTALL_ZIP} \
-        -x ${MC_INSTALL_NAME}/docs/* \
-        -x ${MC_INSTALL_NAME}/*.bat \
-    && rm -rf ${MC_INSTALL_ZIP} \
-    && mv ${MC_INSTALL_NAME}/* . \
-    && rm -rf ${MC_INSTALL_NAME}
+    && curl --silent -o "${MC_HOME}/${MC_JAR}" -L "${MC_JAR_LOCATION}" \
+    && cd ${MC_HOME}
 
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,54 @@
-FROM openjdk:11-jre-slim-sid
+FROM openjdk:11.0.7-jre-slim
 
-ENV MC_VERSION 4.2020.08
-ENV MC_HOME /opt/hazelcast/management-center
-ENV MC_DATA /data
-
-ENV MC_HTTP_PORT 8080
-ENV MC_HTTPS_PORT 8443
-ENV MC_HEALTH_CHECK_PORT 8081
-ENV MC_CONTEXT_PATH /
-
+ARG MC_VERSION=4.2020.08
 ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
 ARG MC_INSTALL_ZIP="${MC_INSTALL_NAME}.zip"
 ARG MC_INSTALL_JAR="hazelcast-management-center-${MC_VERSION}.jar"
 
-ENV MC_RUNTIME "${MC_HOME}/${MC_INSTALL_JAR}"
+# Runtime constants / variables
+ENV MC_HOME="/opt/hazelcast/management-center" \
+    MC_INSTALL_NAME="${MC_INSTALL_NAME}" \
+    MC_INSTALL_ZIP="${MC_INSTALL_ZIP}" \
+    MC_INSTALL_JAR="${MC_INSTALL_JAR}" \
+    MC_DATA="/data" \
+    MC_HTTP_PORT="8080" \
+    MC_HTTPS_PORT="8443" \
+    MC_HEALTH_CHECK_PORT="8081" \
+    LOGGING_LEVEL="" \
+    MC_CONTEXT_PATH="/" \
+    NO_CONTAINER_SUPPORT="false" \
+    MIN_HEAP_SIZE="" \
+    MAX_HEAP_SIZE="" \
+    JAVA_OPTS="" \
+    MC_INIT_SCRIPT="" \
+    MC_INIT_CMD="" \
+    MC_CLASSPATH="" \
+    MC_ADMIN_USER="" \
+    MC_ADMIN_PASSWORD=""
 
-# Install wget to download Management Center
-RUN apt-get update \
- && apt-get install --no-install-recommends --yes \
-      wget unzip \
- && rm -rf /var/lib/apt/lists/*
-
-# chmod allows running container as non-root with `docker run --user` option
-RUN mkdir -p ${MC_HOME} ${MC_DATA} \
- && chmod a+rwx ${MC_HOME} ${MC_DATA}
-WORKDIR ${MC_HOME}
-
-# Prepare Management Center
-RUN wget -O ${MC_HOME}/${MC_INSTALL_ZIP} \
-          http://download.hazelcast.com/management-center/${MC_INSTALL_ZIP} \
- && unzip ${MC_INSTALL_ZIP} \
-      -x ${MC_INSTALL_NAME}/docs/* \
-      -x ${MC_INSTALL_NAME}/*.bat \
- && rm -rf ${MC_INSTALL_ZIP} \
- && mv ${MC_INSTALL_NAME}/* . \
- && rm -rf ${MC_INSTALL_NAME}
-
-# Runtime environment variables
-ENV JAVA_OPTS_DEFAULT "-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true"
-
-ENV NO_CONTAINER_SUPPORT "false"
-ENV MIN_HEAP_SIZE ""
-ENV MAX_HEAP_SIZE ""
-
-ENV JAVA_OPTS ""
-ENV MC_INIT_SCRIPT ""
-ENV MC_INIT_CMD ""
-
-ENV MC_CLASSPATH ""
-
-ENV MC_ADMIN_USER ""
-ENV MC_ADMIN_PASSWORD ""
-
-COPY files/mc-start.sh /mc-start.sh
-RUN chmod +x /mc-start.sh
+RUN echo "Installing new APT packages" \
+    && apt-get update \
+    && apt-get install --no-install-recommends --yes curl unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p ${MC_HOME} ${MC_DATA} \
+    && echo "Granting full access to ${MC_HOME} and ${MC_DATA} to allow running" \
+        "container as non-root with \"docker run --user\" option" \
+    && chmod a+rwx ${MC_HOME} ${MC_DATA} \
+    && echo "Downloading Hazelcast Management Center" \
+    && curl --silent -o "${MC_HOME}/${MC_INSTALL_ZIP}" \
+        -L "http://download.hazelcast.com/management-center/${MC_INSTALL_ZIP}" \
+    && cd ${MC_HOME} \
+    && unzip ${MC_INSTALL_ZIP} \
+        -x ${MC_INSTALL_NAME}/docs/* \
+        -x ${MC_INSTALL_NAME}/*.bat \
+    && rm -rf ${MC_INSTALL_ZIP} \
+    && mv ${MC_INSTALL_NAME}/* . \
+    && rm -rf ${MC_INSTALL_NAME}
 
 VOLUME ["${MC_DATA}"]
-EXPOSE ${MC_HTTP_PORT}
-EXPOSE ${MC_HTTPS_PORT}
-EXPOSE ${MC_HEALTH_CHECK_PORT}
+EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
+
+COPY files/mc-start.sh /mc-start.sh
 
 # Start Management Center
 CMD ["bash", "/mc-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
 
 COPY files/mc-start.sh /mc-start.sh
 
-# uncomment to build with local JAR
+# copy local JAR to project root dir and uncomment to build with it
 # WARNING: mc-conf.sh is used from the downloaded artifact, not from your local JAR
 #COPY hazelcast-management-center-4.2020.10-SNAPSHOT.jar ${MC_HOME}/${MC_JAR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM openjdk:11.0.7-jre-slim
 ARG MC_VERSION=4.2020.08
 ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
 ARG MC_INSTALL_ZIP="${MC_INSTALL_NAME}.zip"
-ARG MC_JAR="hazelcast-management-center-${MC_VERSION}.jar"
 
 # Runtime constants / variables
 ENV MC_HOME="/opt/hazelcast/management-center" \
-    MC_JAR="${MC_JAR}" \
+    MC_JAR="hazelcast-management-center-${MC_VERSION}.jar" \
     MC_DATA="/data" \
     MC_HTTP_PORT="8080" \
     MC_HTTPS_PORT="8443" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,15 @@ RUN echo "Installing new APT packages" \
         "container as non-root with \"docker run --user\" option" \
     && chmod a+rwx ${MC_HOME} ${MC_DATA} \
     && echo "Downloading Hazelcast Management Center" \
-    && curl --silent -o "${MC_HOME}/${MC_JAR}" -L "${MC_JAR_LOCATION}" \
-    && cd ${MC_HOME}
+    && curl -o "${MC_HOME}/${MC_JAR}" "${MC_JAR_LOCATION}"
 
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
 
 COPY files/mc-start.sh /mc-start.sh
+
+# uncomment to build with local JAR
+#COPY hazelcast-management-center-4.2020.10-SNAPSHOT.jar ${MC_HOME}/${MC_JAR}
 
 # Start Management Center
 CMD ["bash", "/mc-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM openjdk:11.0.7-jre-slim
 
 ARG MC_VERSION=4.2020.08
+ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
+ARG MC_INSTALL_ZIP="${MC_INSTALL_NAME}.zip"
 ARG MC_JAR="hazelcast-management-center-${MC_VERSION}.jar"
-ARG MC_JAR_LOCATION="https://download.hazelcast.com/management-center/${MC_JAR}"
 
 # Runtime constants / variables
 ENV MC_HOME="/opt/hazelcast/management-center" \
@@ -23,16 +24,23 @@ ENV MC_HOME="/opt/hazelcast/management-center" \
     MC_ADMIN_USER="" \
     MC_ADMIN_PASSWORD=""
 
-RUN echo "Installing new APT packages" \
+RUN echo "Installing wget and unzip" \
     && apt-get update \
-    && apt-get install --no-install-recommends --yes curl \
+    && apt-get install --no-install-recommends --yes wget unzip \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p ${MC_HOME} ${MC_DATA} \
     && echo "Granting full access to ${MC_HOME} and ${MC_DATA} to allow running" \
         "container as non-root with \"docker run --user\" option" \
     && chmod a+rwx ${MC_HOME} ${MC_DATA} \
     && echo "Downloading Hazelcast Management Center" \
-    && curl -o "${MC_HOME}/${MC_JAR}" "${MC_JAR_LOCATION}"
+    && cd ${MC_HOME} \
+    && wget http://download.hazelcast.com/management-center/${MC_INSTALL_ZIP} \
+    && unzip ${MC_INSTALL_ZIP} \
+             -x ${MC_INSTALL_NAME}/docs/* \
+             -x ${MC_INSTALL_NAME}/*.bat \
+    && rm -rf ${MC_INSTALL_ZIP} \
+    && mv ${MC_INSTALL_NAME}/* . \
+    && rm -rf ${MC_INSTALL_NAME}
 
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
@@ -40,7 +48,9 @@ EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
 COPY files/mc-start.sh /mc-start.sh
 
 # uncomment to build with local JAR
+# WARNING: mc-conf.sh is used from the downloaded artifact, not from your local JAR
 #COPY hazelcast-management-center-4.2020.10-SNAPSHOT.jar ${MC_HOME}/${MC_JAR}
 
 # Start Management Center
+WORKDIR ${MC_HOME}
 CMD ["bash", "/mc-start.sh"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can check [Hazelcast IMDG Documentation](http://docs.hazelcast.org/docs/late
  - [Enabling TLS/SSL]
  - [Hazelcast Member Configuration]
  - [Changing Logging Level]
- - [Using Custom Logback Configuration File]
+ - [Using Custom Log4j Configuration File]
  - [Starting with an Extra Classpath]
  - [Enabling Health Check Endpoint]
  - [Customizing Container Setup]
@@ -96,6 +96,7 @@ Please refer to [the Management Center documentation](https://docs.hazelcast.org
 For the Hazelcast member configuration and the sample Hello World example, please refer to [Hazelcast Docker repository](https://github.com/hazelcast/hazelcast-docker).
 
 ## Changing Logging Level
+[Changing Logging Level]: #changing-logging-level
 
 The logging level can be changed using the `LOGGING_LEVEL` environment variable. For example, to see the `DEBUG` logs:
 
@@ -112,17 +113,19 @@ Note that if you need a more customized logging configuration, you can specify a
 $ docker run -v <config-file-path>:/opt/hazelcast/log4j2-custom.properties hazelcast/hazelcast
 ```
 
-## Using Custom Logback Configuration File
-[Using Custom Logback Configuration File]: #using-custom-logback-configuration-file
+## Using Custom Log4j Configuration File
+[Using Custom Log4j Configuration File]: #using-custom-log4j-configuration-file
 
-Management Center can use your custom Logback configuration file. You need to create a mount to a folder named `/opt/hazelcast/mc_ext`, see the following on how to do it. `PATH_TO_PERSISTENT_FOLDER` must be replaced with the path to the folder that your custom Logback configuration file resides in. `CUSTOM_LOGBACK_FILE` must be replaced with the name of your custom Logback configuration file, for example `logback-custom.xml`.
+Management Center can use your custom Log4j configuration file. You need to create a mount to a folder named 
+`/opt/hazelcast/mc_ext`, see the following on how to do it. `PATH_TO_PERSISTENT_FOLDER` must be replaced with 
+the path to the folder that your custom Log4j configuration file resides in. `CUSTOM_LOG4J_FILE` must be 
+replaced with the name of your custom Log4j configuration file, for example `log4j2-custom.properties`.
 
 ```
-docker run -m 512m \
-         -e JAVA_OPTS='-Dlogback.configurationFile=/opt/hazelcast/mc_ext/CUSTOM_LOGBACK_FILE' \
-         -v PATH_TO_LOCAL_FOLDER:/opt/hazelcast/mc_ext \
-         -p 8080:8080 \
-         hazelcast/management-center
+docker run -e JAVA_OPTS='-Dlog4j.configurationFile=/opt/hazelcast/mc_ext/CUSTOM_LOG4J_FILE' \
+           -v PATH_TO_LOCAL_FOLDER:/opt/hazelcast/mc_ext \
+           -p 8080:8080 \
+           hazelcast/management-center
 ```
 
 ## Starting with an Extra Classpath

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The commands defined by the variables are executed before starting the Managemen
 You can start Management Center with an administrative user by setting the following optional environment variables:
 
 ```
-docker run -ti  --name hazelcast-mc \
+docker run --name hazelcast-mc \
          --env MC_ADMIN_USER=admin \
          --env MC_ADMIN_PASSWORD=myPassword11 \
          --rm hazelcast/management-center
@@ -209,7 +209,7 @@ following environment variables:
 Example:
 
 ```
-docker run -ti --rm --name hazelcast-mc \
+docker run --rm --name hazelcast-mc \
            -e CONTAINER_SUPPORT='false' \
            -e MIN_HEAP_SIZE='512M' \
            -e MAX_HEAP_SIZE='1024M' \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can check [Hazelcast IMDG Documentation](http://docs.hazelcast.org/docs/late
  - [Mounting Management Center Home Directory]
  - [Enabling TLS/SSL]
  - [Hazelcast Member Configuration]
+ - [Changing Logging Level]
  - [Using Custom Logback Configuration File]
  - [Starting with an Extra Classpath]
  - [Enabling Health Check Endpoint]
@@ -93,6 +94,23 @@ Please refer to [the Management Center documentation](https://docs.hazelcast.org
 [Hazelcast Member Configuration]: #hazelcast-member-configuration
 
 For the Hazelcast member configuration and the sample Hello World example, please refer to [Hazelcast Docker repository](https://github.com/hazelcast/hazelcast-docker).
+
+## Changing Logging Level
+
+The logging level can be changed using the `LOGGING_LEVEL` environment variable. For example, to see the `DEBUG` logs:
+
+```
+$ docker run -e LOGGING_LEVEL=DEBUG hazelcast/management-center
+```
+
+Available logging levels are (from highest to lowest): `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE` and `ALL`. 
+Invalid levels will be assumed `OFF`.
+
+Note that if you need a more customized logging configuration, you can specify a configuration file.
+
+```
+$ docker run -v <config-file-path>:/opt/hazelcast/log4j2-custom.properties hazelcast/hazelcast
+```
 
 ## Using Custom Logback Configuration File
 [Using Custom Logback Configuration File]: #using-custom-logback-configuration-file

--- a/README.md
+++ b/README.md
@@ -22,43 +22,51 @@ You can check [Hazelcast IMDG Documentation](http://docs.hazelcast.org/docs/late
 ## Quick Start
 [Quick Start]: #quick-start
 
-You can launch Hazelcast Management Center by simply running the following command. Please check available versions for $MANAGEMENT_CENTER on [Docker Store](https://store.docker.com/community/images/hazelcast/management-center/tags)
+You can launch Hazelcast Management Center by simply running the following command. Please check available 
+versions for `$MANAGEMENT_CENTER` on [Docker Hub](https://hub.docker.com/r/hazelcast/management-center/tags).
 
 ```
-docker run --rm -m 512m -p 8080:8080 hazelcast/management-center:$MANAGEMENT_CENTER
+docker run --rm -p 8080:8080 hazelcast/management-center:$MANAGEMENT_CENTER
 ```
 
-**NOTE:** Please, make sure that you are not using `latest` tag, because 3.x and 4.x versions are not compatible. You can check [Supported Environments](https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#supported-environments) section for more info on version compatibility between Management Center and IMDG/Jet clusters.
+**NOTE:** Please, make sure you are not using `latest` tag, because 3.x and 4.x versions are not compatible. 
+You can check [Supported Environments](https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#supported-environments)
+section for more info on version compatibility between Management Center and Hazelcast/Hazelcast Jet clusters.
 
-Now you can reach Hazelcast Management Center from your browser using the URL `http://localhost:8080`. 
+Now you can access Hazelcast Management Center from your browser using the URL `http://localhost:8080`. 
 
 If you are running the Docker image in the cloud, you should use a public IP of your machine instead of `localhost`. 
 
-`docker ps` and `docker inspect <container-id>` can be used to find `host-ip`. Once you find out `host-ip`, you can browse Hazelcast Management Center using the URL: `http://host-ip:8080`.
+Both `docker ps` and `docker inspect <container-id>` can be used to find `host-ip`. Once you find out `host-ip`, 
+you can browse Hazelcast Management Center using the URL: `http://host-ip:8080`.
 
-By default the container automatically sizes the java heap memory suitable to the specified resource limit or available memory.
+By default, the container automatically sizes the Java heap memory suitable to the specified resource limit or 
+available memory.
 
 ### Management Center Default Context Path
 
 Before version 4.0, default context path was `/hazelcast-mancenter`, so you would access Hazelcast 
-Management Center by using `http://localhost:8080/hazelcast-mancenter`. Starting with the version 4.0, 
+Management Center by using `http://localhost:8080/hazelcast-mancenter`. Starting with version 4.0, 
 it is changed to root context path (i.e. `/`), so you can access it by using `http://localhost:8080`.
 
-You can overwrite this default by setting the environment variable `MC_CONTEXT_PATH`.
+You can override this default by setting the environment variable `MC_CONTEXT_PATH`.
 
 ## Mounting Management Center Home Directory
 [Mounting Management Center Home Directory]: #mounting-management-center-home-directory
 
-Management Center uses the file system to store persistent data. However, that is by default inside the docker container and destroyed in case of container restarts. If you want to store Management Center data externally, you need to create a mount to a folder named `/data`. See the following for how to create a mount point. `PATH_TO_PERSISTENT_FOLDER` must be replaced by your persistent folder.
+Management Center uses the file system to store persistent data. However, that is by default inside the Docker 
+container and destroyed in case of container restarts. If you want to store Management Center data externally, 
+you need to create a mount to a folder named `/data`. See the following for how to create a mount point. 
+`PATH_TO_PERSISTENT_FOLDER` must be replaced by your persistent folder.
 
 ```
-docker run --rm -m 512m -p 8080:8080 -v PATH_TO_PERSISTENT_FOLDER:/data hazelcast/management-center:$MANAGEMENT_CENTER
+docker run --rm -p 8080:8080 -v PATH_TO_PERSISTENT_FOLDER:/data hazelcast/management-center:$MANAGEMENT_CENTER
 ```
 
-To provide a license key the system property `hazelcast.mc.license` can be used (requires version >= 3.9.3):
+To provide a license key, the command line argument `-Dhazelcast.mc.license` can be used (requires version 3.9.3 or newer):
 
 ```
-docker run --rm -m 512m -e JAVA_OPTS='-Dhazelcast.mc.license=<key>' -p 8080:8080 hazelcast/management-center:$MANAGEMENT_CENTER
+docker run --rm -e JAVA_OPTS='-Dhazelcast.mc.license=<key>' -p 8080:8080 hazelcast/management-center:$MANAGEMENT_CENTER
 ```
 
 ## Enabling TLS/SSL
@@ -67,7 +75,7 @@ docker run --rm -m 512m -e JAVA_OPTS='-Dhazelcast.mc.license=<key>' -p 8080:8080
 To enable TLS/SSL, you need to provide the keystore and expose the default port (`8443`):
 
 ```
-docker run --rm -m 512m \
+docker run --rm \
          -e JAVA_OPTS='-Dhazelcast.mc.tls.enabled=true \
          -Dhazelcast.mc.tls.keyStore=/keystore/yourkeystore.jks \
          -Dhazelcast.mc.tls.keyStorePassword=yourpassword' \
@@ -76,10 +84,11 @@ docker run --rm -m 512m \
          hazelcast/management-center
 ```
 
-The default port can be changed by overriding the `MC_HTTPS_PORT` environment variable. For example, to use port `8444` you can run the following command:
+The default port can be changed by overriding the `MC_HTTPS_PORT` environment variable. For example, 
+you can run the following command to use port `8444`:
 
 ```
-docker run --rm -m 512m -e MC_HTTPS_PORT=8444 \
+docker run --rm -e MC_HTTPS_PORT=8444 \
         -e JAVA_OPTS='-Dhazelcast.mc.tls.enabled=true \
         -Dhazelcast.mc.tls.keyStore=/keystore/yourkeystore.jks \
         -Dhazelcast.mc.tls.keyStorePassword=yourpassword' \
@@ -88,12 +97,15 @@ docker run --rm -m 512m -e MC_HTTPS_PORT=8444 \
         hazelcast/management-center
 ```
 
-Please refer to [the Management Center documentation](https://docs.hazelcast.org/docs/management-center/3.12/manual/html/index.html#enabling-tslssl-when-starting-with-war-file) for more information on available options.
+Please refer to 
+[Management Center Reference Manual](https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#enabling-tslssl-when-starting-with-jar-file) 
+for more information on available options.
 
 ## Hazelcast Member Configuration
 [Hazelcast Member Configuration]: #hazelcast-member-configuration
 
-For the Hazelcast member configuration and the sample Hello World example, please refer to [Hazelcast Docker repository](https://github.com/hazelcast/hazelcast-docker).
+For the Hazelcast member configuration and the sample Hello World example, please refer to 
+[Hazelcast Docker repository](https://github.com/hazelcast/hazelcast-docker).
 
 ## Changing Logging Level
 [Changing Logging Level]: #changing-logging-level
@@ -131,24 +143,27 @@ docker run -e JAVA_OPTS='-Dlog4j.configurationFile=/opt/hazelcast/mc_ext/CUSTOM_
 ## Starting with an Extra Classpath
 [Starting with an Extra Classpath]: #starting-with-an-extra-classpath
 
-You can start the Management Center with an extra classpath entry (for example, when using JAAS authentication) by using the `MC_CLASSPATH` environment variable:
+You can start Management Center with an extra classpath entry (for example, when using JAAS authentication) 
+by using the `MC_CLASSPATH` environment variable:
 
 ```
-docker run -m 512m -e MC_CLASSPATH='/path/to/your-extra.jar' -p 8080:8080 hazelcast/management-center
+docker run -e MC_CLASSPATH='/path/to/your-extra.jar' -p 8080:8080 hazelcast/management-center
 ```
 
 ## Enabling Health Check Endpoint
 [Enabling Health Check Endpoint]: #enabling-health-check-endpoint
 
-When running the Management Center, you can enable the Health Check endpoint:
+When running Management Center, you can enable the Health Check endpoint:
 
 ```
-docker run -m 512m -p 8080:8080 -p 8081:8081 \
-         -e JAVA_OPTS='-Dhazelcast.mc.healthCheck.enable=true' \
-         hazelcast/management-center:$MANAGEMENT_CENTER
+docker run -p 8080:8080 -p 8081:8081 \
+           -e JAVA_OPTS='-Dhazelcast.mc.healthCheck.enable=true' \
+           hazelcast/management-center:$MANAGEMENT_CENTER
 ```
 
-This endpoint may be used in container-orchestraction systems, like Kubernetes. Refer to [the Management Center documentation](https://docs.hazelcast.org/docs/management-center/3.12.5/manual/html/index.html#enabling-health-check-endpoint) for more information.
+You can use this endpoint with container orchestraction systems, like Kubernetes. Refer to 
+[Management Center Reference Manual](https://docs.hazelcast.org/docs/management-center/latest/manual/html/#enabling-health-check-endpoint) 
+for more information.
 
 ## Customizing Container Setup
 [Customizing Container Setup]: #customizing-container-setup
@@ -156,16 +171,18 @@ This endpoint may be used in container-orchestraction systems, like Kubernetes. 
 You can make modifications to the container on container startup by defining environment variables.
 
 * `MC_INIT_CMD`: Execute one or more commands separated by semicolons.
-* `MC_INIT_SCRIPT`: Execute a script in bash syntax in the context of the [entry-script](files/mc-start.sh). Make this file available by layering to a new container or by assigning a docker volume.
+* `MC_INIT_SCRIPT`: Execute a script in Bash syntax in the context of the [entry-script](files/mc-start.sh). 
+Make this file available by layering to a new container or by assigning a Docker volume.
 
 The commands defined by the variables are executed before starting the Management Center in the listed order.
 
 ## Start with a Preconfigured Admin User
 [Start with a Preconfigured Admin User]: #start-with-a-preconfigured-admin-user
 
-You can start the Management Center with an administrative user by setting the following optional environmental variables:
+You can start Management Center with an administrative user by setting the following optional environment variables:
+
 ```
-docker run -m 512m -ti  --name hazelcast-mc \
+docker run -ti  --name hazelcast-mc \
          --env MC_ADMIN_USER=admin \
          --env MC_ADMIN_PASSWORD=myPassword11 \
          --rm hazelcast/management-center
@@ -174,28 +191,38 @@ docker run -m 512m -ti  --name hazelcast-mc \
 ## JVM Heap Configuration
 [JVM Heap Configuration]: #jvm-heap-configuration
 
-By default the container uses the `-XX:+UseContainerSupport -XX:MaxRAMPercentage=80` java options to automatically size the memory available to the jvm.
-If you don't use the memory resource limit (i.e. `docker run -m 512m ...`, or the limit of a docker orchestration solutions like [Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)) the container might use up to 80% percent of the available system memory.
+By default, the container uses `-XX:+UseContainerSupport -XX:MaxRAMPercentage=80` Java options to automatically size 
+the memory available to the JVM. If you don't use the memory resource limit (i.e. `docker run -m 512m ...`, or the 
+limit of a Docker orchestration solution like 
+[Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)), the container might 
+use up to 80% percent of the available system memory.
 
-You can define the following variables:
+You can define the following variables to change this behavior:
 
 * `CONTAINER_SUPPORT="true"` (default) : use automatic memory resource configuration
-* `CONTAINER_SUPPORT="false"` : suppress automatic resource configuration and configure the limits by using the following environment variables:
+* `CONTAINER_SUPPORT="false"` : suppress automatic resource configuration and configure the limits by using the 
+following environment variables:
    * `MIN_HEAP_SIZE` : set the minium heap by `-Xms ...` 
    * `MAX_HEAP_SIZE` : set the maximum heap by `-Xmx ...`
    * `JAVA_OPTS` : use a custom configuration like `-Xms64m -Xmn1024m -Xmx2G -XX:MaxGCPauseMillis=200`
 
 Example:
+
 ```
-docker run -ti  --name hazelcast-mc \
-         -e CONTAINER_SUPPORT='false' -e MIN_HEAP_SIZE='512M' -e MAX_HEAP_SIZE='1024M' -e JAVA_OPTS='-XX:MaxGCPauseMillis=200' \
-         --rm hazelcast/management-center
+docker run -ti --rm --name hazelcast-mc \
+           -e CONTAINER_SUPPORT='false' \
+           -e MIN_HEAP_SIZE='512M' \
+           -e MAX_HEAP_SIZE='1024M' \
+           -e JAVA_OPTS='-XX:MaxGCPauseMillis=200' \
+           hazelcast/management-center
 ```
 
 ## Configuring Management Center Inside Your Custom Docker Image
 [Configuring Management Center Inside Your Custom Docker Image]: #configuring-management-center-inside-your-custom-docker-image
 
-If you create Docker image with `hazelcast/management-center` as a base image and want to make additional configuration using `mc-conf.sh`, you have to specify `--home="${MC_DATA}"` flag for each `mc-conf` command. That makes sure that `mc-conf` stores data to the same directory that Management Center will use at runtime.
+If you create a Docker image with `hazelcast/management-center` as the base image and want to configure it further 
+using `mc-conf.sh`, you need to specify `--home="${MC_DATA}"` flag for each `mc-conf` command. It makes sure that 
+`mc-conf` stores data in the same directory that Management Center will use at runtime.
 
 For example:
 
@@ -213,4 +240,5 @@ CMD ["bash", "-c", "set -euo pipefail \
      "]
 ```
 
-**NOTE:** `$MC_DATA` env variable is coming from `hazelcast/management-center`. It is used to save the configuration and other needed data when running Management Center.
+**NOTE:** `$MC_DATA` env variable comes from `hazelcast/management-center`. It is used to save the configuration and 
+any other data needed when running Management Center.

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -26,7 +26,7 @@ else
     export JAVA_OPTS="${JAVA_OPTS} -XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
 fi
 
-export MC_RUNTIME="${MC_HOME}/${MC_INSTALL_JAR}"
+export MC_RUNTIME="${MC_HOME}/${MC_JAR}"
 if [ -n "${MC_CLASSPATH}" ]; then
     export MC_CLASSPATH="${MC_RUNTIME}:${MC_CLASSPATH}"
 else

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -47,6 +47,7 @@ fi
 if [ -n "${MC_ADMIN_USER}" ] && [ -n "${MC_ADMIN_PASSWORD}" ]; then
   echo "Creating admin user."
   source ./mc-conf.sh user create --lenient=true -H="${MC_DATA}" -n="${MC_ADMIN_USER}" -p="${MC_ADMIN_PASSWORD}" -r=admin
+  # shellcheck disable=SC2181
   if [ $? -eq 0 ]; then
     echo "User created successfully."
   else
@@ -60,6 +61,7 @@ echo "##################################################"
 
 # --add-opens flag is required to prevent this issue: https://jira.spring.io/browse/SPR-15859
 set -x
+# shellcheck disable=SC2086
 exec java \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     -server ${JAVA_OPTS} \

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -14,7 +14,7 @@ if [ -n "${LOGGING_LEVEL}" ]; then
 fi
 
 if [ "${CONTAINER_SUPPORT:-true}" = "false" ] ;then
-    echo "Container support disabled. Using manual heap sizing by specifying MIN_HEAP_SIZE, MAX_HEAP_SIZE or custom settings configured by JAVA_OPTS."
+    echo "Container support disabled. Using manual heap sizing by specifying MIN_HEAP_SIZE, MAX_HEAP_SIZE or custom settings configured by JAVA_OPTS." 1>&2
     if [ -n "${MIN_HEAP_SIZE}" ]; then
         export JAVA_OPTS="${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}"
     fi
@@ -22,7 +22,7 @@ if [ "${CONTAINER_SUPPORT:-true}" = "false" ] ;then
         export JAVA_OPTS="${JAVA_OPTS} -Xmx${MAX_HEAP_SIZE}"
     fi
 else
-    echo "Container support enabled. Using automatic heap sizing. JVM will use up to 80% of the memory limit of the container."
+    echo "Container support enabled. Using automatic heap sizing. JVM will use up to 80% of the memory limit of the container." 1>&2
     export JAVA_OPTS="${JAVA_OPTS} -XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
 fi
 
@@ -34,30 +34,30 @@ else
 fi
 
 if [ -n "${MC_INIT_CMD}" ]; then
-   echo "Executing command specified by MC_INIT_CMD for container initialization."
+   echo "Executing command specified by MC_INIT_CMD for container initialization." 1>&2
    eval "${MC_INIT_CMD}"
 fi
 
 if [ -n "${MC_INIT_SCRIPT}" ]; then
-    echo "Loading script $MC_INIT_SCRIPT specified by MC_INIT_SCRIPT for container initialization."
+    echo "Loading script $MC_INIT_SCRIPT specified by MC_INIT_SCRIPT for container initialization." 1>&2
     # shellcheck source=/dev/null
     source "${MC_INIT_SCRIPT}"
 fi
 
 if [ -n "${MC_ADMIN_USER}" ] && [ -n "${MC_ADMIN_PASSWORD}" ]; then
-  echo "Creating admin user."
+  echo "Creating admin user."  1>&2
   source ./mc-conf.sh user create --lenient=true -H="${MC_DATA}" -n="${MC_ADMIN_USER}" -p="${MC_ADMIN_PASSWORD}" -r=admin
   # shellcheck disable=SC2181
   if [ $? -eq 0 ]; then
-    echo "User created successfully."
+    echo "User created successfully." 1>&2
   else
     exit 1
   fi
 fi
 
-echo "##################################################"
-echo "# Initialisation complete, starting now....      #"
-echo "##################################################"
+echo "##################################################" 1>&2
+echo "# Initialisation complete, starting now....      #" 1>&2
+echo "##################################################" 1>&2
 
 # --add-opens flag is required to prevent this issue: https://jira.spring.io/browse/SPR-15859
 set -x

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -65,7 +65,7 @@ set -x
 exec java \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     -server ${JAVA_OPTS} \
-    -cp ${MC_CLASSPATH} \
+    -cp "${MC_CLASSPATH}" \
     -Dhazelcast.mc.contextPath=${MC_CONTEXT_PATH} \
     -Dhazelcast.mc.http.port=${MC_HTTP_PORT} \
     -Dhazelcast.mc.https.port=${MC_HTTPS_PORT} \

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+
+export JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true"
 if [ -n "${JAVA_OPTS}" ]; then
     export JAVA_OPTS="${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}"
 else
     export JAVA_OPTS="${JAVA_OPTS_DEFAULT}"
+fi
+
+if [ -n "${LOGGING_LEVEL}" ]; then
+    export JAVA_OPTS="-Dhazelcast.mc.log.level=${LOGGING_LEVEL} ${JAVA_OPTS}"
 fi
 
 if [ "${CONTAINER_SUPPORT:-true}" = "false" ] ;then
@@ -20,6 +26,7 @@ else
     export JAVA_OPTS="${JAVA_OPTS} -XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
 fi
 
+export MC_RUNTIME="${MC_HOME}/${MC_INSTALL_JAR}"
 if [ -n "${MC_CLASSPATH}" ]; then
     export MC_CLASSPATH="${MC_RUNTIME}:${MC_CLASSPATH}"
 else

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -14,7 +14,7 @@ if [ -n "${LOGGING_LEVEL}" ]; then
 fi
 
 if [ "${CONTAINER_SUPPORT:-true}" = "false" ] ;then
-    echo "using manual heap sizing by specifying MIN_HEAP_SIZE or MAX_HEAP_SIZE or custom settings configure by JAVA_OPTS"
+    echo "Container support disabled. Using manual heap sizing by specifying MIN_HEAP_SIZE, MAX_HEAP_SIZE or custom settings configured by JAVA_OPTS."
     if [ -n "${MIN_HEAP_SIZE}" ]; then
         export JAVA_OPTS="${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}"
     fi
@@ -22,7 +22,7 @@ if [ "${CONTAINER_SUPPORT:-true}" = "false" ] ;then
         export JAVA_OPTS="${JAVA_OPTS} -Xmx${MAX_HEAP_SIZE}"
     fi
 else
-    echo "using automatic sizing of heap size by up to 80% of available memory and starting with container support"
+    echo "Container support enabled. Using automatic heap sizing. JVM will use up to 80% of the memory limit of the container."
     export JAVA_OPTS="${JAVA_OPTS} -XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
 fi
 
@@ -34,27 +34,28 @@ else
 fi
 
 if [ -n "${MC_INIT_CMD}" ]; then
-   echo "executing command specified by MC_INIT_CMD for container initialization"
+   echo "Executing command specified by MC_INIT_CMD for container initialization."
    eval "${MC_INIT_CMD}"
 fi
 
 if [ -n "${MC_INIT_SCRIPT}" ]; then
-    echo "loading script $MC_INIT_SCRIPT specified by MC_INIT_SCRIPT for container initialization"
-    source ${MC_INIT_SCRIPT}
+    echo "Loading script $MC_INIT_SCRIPT specified by MC_INIT_SCRIPT for container initialization."
+    # shellcheck source=/dev/null
+    source "${MC_INIT_SCRIPT}"
 fi
 
 if [ -n "${MC_ADMIN_USER}" ] && [ -n "${MC_ADMIN_PASSWORD}" ]; then
-  echo "Creating admin user"
-  source ./mc-conf.sh user create --lenient=true -H=${MC_DATA} -n=${MC_ADMIN_USER} -p=${MC_ADMIN_PASSWORD} -r=admin
+  echo "Creating admin user."
+  source ./mc-conf.sh user create --lenient=true -H="${MC_DATA}" -n="${MC_ADMIN_USER}" -p="${MC_ADMIN_PASSWORD}" -r=admin
   if [ $? -eq 0 ]; then
-    echo "User created successfully"
+    echo "User created successfully."
   else
     exit 1
   fi
 fi
 
 echo "##################################################"
-echo "# initialisation complete, starting now...."
+echo "# Initialisation complete, starting now....      #"
 echo "##################################################"
 
 # --add-opens flag is required to prevent this issue: https://jira.spring.io/browse/SPR-15859
@@ -62,7 +63,7 @@ set -x
 exec java \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     -server ${JAVA_OPTS} \
-    -cp "${MC_CLASSPATH}" \
+    -cp ${MC_CLASSPATH} \
     -Dhazelcast.mc.contextPath=${MC_CONTEXT_PATH} \
     -Dhazelcast.mc.http.port=${MC_HTTP_PORT} \
     -Dhazelcast.mc.https.port=${MC_HTTPS_PORT} \


### PR DESCRIPTION
`LOGGING_LEVEL` environment variable can be used to set Management Center log level globally.

Other changes:
* Upgrade the base Docker image and the JDK we use
* Clean up `Dockerfile` to be more concise 
* Improve messages in `mc-start.sh` script and `README`