### PR TITLE
Don't run vuln. scan on each PR

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,8 +1,6 @@
 name: Vulnerability Scan
 
 on:
-  pull_request_target:
-    branches: master
   schedule:
     - cron: '0 2 * * *'
 


### PR DESCRIPTION
It is currently broken and runs the scan against the base branch. Until
we fix it, there's no point in spending GH actions minutes on it.