### PR TITLE
Add hazelcast.mc.revision Docker label

### DIFF
--- a/.github/workflows/publish_latest_snapshot.yml
+++ b/.github/workflows/publish_latest_snapshot.yml
@@ -6,6 +6,9 @@ on:
       mcVersion:
         description: 'MC Version'
         required: true
+      mcRevision:
+        description: 'MC Revision'
+        required: true
 
 jobs:
   publish_latest_snapshot:
@@ -33,6 +36,7 @@ jobs:
         run: |
           docker buildx build --push \
             --build-arg MC_VERSION=${{ github.event.inputs.mcVersion }} \
+            --build-arg MC_REVISION=${{ github.event.inputs.mcRevision }} \
             --build-arg MC_INSTALL_ZIP=management-center-latest-snapshot.zip \
             --tag hazelcast/management-center:latest-snapshot \
             --platform=linux/arm64,linux/amd64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ ARG MC_VERSION
 ARG MC_INSTALL_NAME
 ARG MC_INSTALL_JAR
 ARG MC_INSTALL_ZIP
+ARG MC_REVISION=${MC_VERSION}
+
+LABEL hazelcast.mc.revision=${MC_REVISION}
 
 ENV MC_HOME=/opt/hazelcast/management-center \
     MC_DATA=/data


### PR DESCRIPTION
Also update the GH actions job so that it takes
the revision as an input and uses it for populating
the label.

PR in main repo: https://github.com/hazelcast/management-center/pull/4161