### PR TITLE
MC-126 - specify MC_DATA as a home dir in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ LABEL hazelcast.mc.revision=${MC_REVISION}
 ENV MC_HOME=/opt/hazelcast/management-center \
     MC_DATA=/data
 
-ENV MC_INSTALL_JAR="${MC_INSTALL_JAR}" \
+ENV JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true" \
+    MC_INSTALL_JAR="${MC_INSTALL_JAR}" \
     USER_NAME="hazelcast" \
     USER_UID=10001 \
     MC_HTTP_PORT="8080" \

--- a/README.md
+++ b/README.md
@@ -220,9 +220,8 @@ docker run --rm --name hazelcast-mc \
 ## Configuring Management Center Inside Your Custom Docker Image
 [Configuring Management Center Inside Your Custom Docker Image]: #configuring-management-center-inside-your-custom-docker-image
 
-If you create a Docker image with `hazelcast/management-center` as the base image and want to configure it further 
-using `mc-conf.sh`, you need to specify `--home="${MC_DATA}"` flag for each `mc-conf` command. It makes sure that 
-`mc-conf` stores data in the same directory that Management Center will use at runtime.
+You can create a Docker image with `hazelcast/management-center` as the base image and configure it further 
+using `mc-conf.sh`.
 
 For example:
 
@@ -235,10 +234,7 @@ ENV MC_CLUSTER1_ADDRESSLIST=127.0.0.1:5701
 
 # Start Management Center
 CMD ["bash", "-c", "set -euo pipefail \
-      && ./mc-conf.sh cluster add --cluster-name=\"${MC_CLUSTER1_NAME}\" --member-addresses=\"${MC_CLUSTER1_ADDRESSLIST}\" --home=\"${MC_DATA}\" \
+      && ./mc-conf.sh cluster add --cluster-name=\"${MC_CLUSTER1_NAME}\" --member-addresses=\"${MC_CLUSTER1_ADDRESSLIST}\" \
       && ./mc-start.sh \
      "]
 ```
-
-**NOTE:** `$MC_DATA` env variable comes from `hazelcast/management-center`. It is used to save the configuration and 
-any other data needed when running Management Center.

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-export JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true"
 if [ -n "${JAVA_OPTS}" ]; then
     export JAVA_OPTS="${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}"
 else
@@ -46,7 +45,7 @@ fi
 
 if [ -n "${MC_ADMIN_USER}" ] && [ -n "${MC_ADMIN_PASSWORD}" ]; then
   echo "Creating admin user."  1>&2
-  source ./bin/mc-conf.sh user create --lenient=true -H="${MC_DATA}" -n="${MC_ADMIN_USER}" -p="${MC_ADMIN_PASSWORD}" -r=admin
+  source ./bin/mc-conf.sh user create --lenient=true -n="${MC_ADMIN_USER}" -p="${MC_ADMIN_PASSWORD}" -r=admin
   # shellcheck disable=SC2181
   if [ $? -eq 0 ]; then
     echo "User created successfully." 1>&2


### PR DESCRIPTION
Changes:
- specify JAVA_OPTS_DEFAULT in the base Dockerfile instead of mc-start.sh to make this env variable available in mc-conf.sh runs
- README updated