### PR TITLE
Adding --illegal-access=permit flag by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ LABEL hazelcast.mc.revision=${MC_REVISION}
 ENV MC_HOME=/opt/hazelcast/management-center \
     MC_DATA=/data
 
-ENV JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true" \
+ENV JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true --illegal-access=permit" \
     MC_INSTALL_JAR="${MC_INSTALL_JAR}" \
     USER_NAME="hazelcast" \
     USER_UID=10001 \


### PR DESCRIPTION
Adding `--illegal-access=permit` option by default to `JAVA_OPTS` so that MC stdout doesn't include unnecessary warnings.

Related slack thread: https://hazelcast.slack.com/archives/C0151J6CSDC/p1636382653081300