### PR TITLE
MC-1107 re-enabling container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack
     MC_HEALTH_CHECK_PORT="8081" \
     LOGGING_LEVEL="" \
     MC_CONTEXT_PATH="/" \
-    NO_CONTAINER_SUPPORT="false" \
+    CONTAINER_SUPPORT="true" \
     MIN_HEAP_SIZE="" \
     MAX_HEAP_SIZE="" \
     JAVA_OPTS="" \


### PR DESCRIPTION
Container support (`+UseContainerSupport` JVM flag was disabled by default in the `mc-start.sh` in https://github.com/hazelcast/management-center/pull/5159 . This makes sense because this flag should be off when someone starts MC outside docker. But in docker we want to use it so we should explicitly pass the parameter.