### PR TITLE
Re-add mc-start.sh for backward compatibility HZ-626

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,9 @@ RUN echo "Adding non-root user" \
     && adduser --uid $USER_UID --system --home $MC_HOME --shell /sbin/nologin $USER_NAME \
     && chown -R $USER_UID:0 $MC_HOME ${MC_DATA} \
     && chmod -R g=u "$MC_HOME" ${MC_DATA} \
-    && chmod -R +r $MC_HOME ${MC_DATA}
+    && chmod -R +r $MC_HOME ${MC_DATA} \
+    && echo "Setting mc-start.sh permissions" \
+    && chmod +x ./bin/mc-start.sh
 
 # Switch to hazelcast user
 USER ${USER_UID}

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ COPY --from=builder /tmp/build/${MC_INSTALL_JAR} .
 COPY --from=builder /tmp/build/start.sh ./bin/start.sh
 COPY --from=builder /tmp/build/mc-conf.sh ./bin/mc-conf.sh
 COPY --from=builder /tmp/build/hz-mc ./bin/hz-mc
+COPY files/mc-start.sh ./bin/mc-start.sh
 
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
@@ -88,6 +89,4 @@ RUN echo "Adding non-root user" \
 USER ${USER_UID}
 
 # Start Management Center
-CMD ["bash", "-c" , "./bin/hz-mc start -Dhazelcast.mc.contextPath=${MC_CONTEXT_PATH} \
-                                          -Dhazelcast.mc.http.port=${MC_HTTP_PORT} \
-                                          -Dhazelcast.mc.https.port=${MC_HTTPS_PORT}"]
+CMD ["bash", "./bin/mc-start.sh"]

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")" && cd ..
+
+./bin/hz-mc start "$@"

--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")" && cd ..
+cd "$(dirname "$0")/.."
 
 ./bin/hz-mc start "$@"


### PR DESCRIPTION
Related to: 
 - https://github.com/hazelcast/management-center-docker/pull/102
 - https://hazelcast.atlassian.net/browse/HZ-626

Re-adda `mc-start.sh` to be backward compatible with custom MC docker images created by users.

# Testing 
- switched to a local MC zip file and built the image:
```shell
docker build --build-arg MC_VERSION=5.1-SNAPSHOT --build-arg MC_INSTALL_ZIP=hazelcast-management-center-latest-snapshot.zip --tag hazelcast/management-center:test . 
```

Run the image:
```shell
 docker run --rm -it -p 8080:8080 -e "MC_CONTEXT_PATH=/lukasz" -e JAVA_OPTS="-Dhazelcast.mc.healthCheck.enable=true -Dhazelcast.mc.healthCheck.port=2000" hazelcast/management-center:test
```