### PR TITLE
Fix stopping with CTRL+C MC-1423

### DIFF
--- a/files/mc-start.sh
+++ b/files/mc-start.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-./bin/hz-mc start "$@"
+exec ./bin/hz-mc start "$@"


### PR DESCRIPTION
Fixes https://hazelcast.atlassian.net/browse/MC-1423

### Testing

After pressing CTRL+C (`^C`) we see the cleanup in the last line:
```
docker run --rm -p 8080:8080  local-management-center
Container support enabled. Using automatic heap sizing. JVM will use up to 80% of the memory limit of the host.
+ exec java -server --add-opens java.base/java.lang=ALL-UNNAMED -Dhazelcast.mc.home=/data -Djava.net.preferIPv4Stack=true -XX:+UseContainerSupport -XX:MaxRAMPercentage=80 -cp 'hazelcast-management-center-5.1.1.jar:./bin/user-lib/*' com.hazelcast.webmonitor.Launcher
2022-03-18 11:14:58,794 [ INFO] [main] [c.h.w.c.BuildInfo]: Hazelcast Management Center 5.1.1 (20220301 - 19e3039), Hazelcast client version: 5.1, embedded Jetty version: 9.4.45.v20220203
2022-03-18 11:15:02,207 [ INFO] [main] [c.h.w.c.SqlDbConfig]: Checking DB for required migrations.
2022-03-18 11:15:03,232 [ INFO] [main] [c.h.w.c.SqlDbConfig]: Number of applied DB migrations: 16.
2022-03-18 11:15:04,018 [ INFO] [main] [c.h.w.s.s.i.DisableLoginStrategy]: Login will be disabled for 5 seconds after 3 failed login attempts. For every 3 consecutive failed login attempts, disable period will be multiplied by 10.
2022-03-18 11:15:05,678 [ WARN] [main] [o.s.s.c.a.w.b.WebSecurity]: You are asking Spring Security to ignore Ant [pattern='/api/buildInfo']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-03-18 11:15:05,681 [ WARN] [main] [o.s.s.c.a.w.b.WebSecurity]: You are asking Spring Security to ignore Ant [pattern='/api/swagger-ui/config']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-03-18 11:15:07,394 [ INFO] [AsyncExecutor-1] [c.h.w.s.ClusterManager]: Connecting to 0 enabled cluster(s) on startup.
2022-03-18 11:15:07,904 [ INFO] [main] [c.h.w.Launcher]: Hazelcast Management Center successfully started at http://localhost:8080/
^C2022-03-18 11:15:37,768 [ INFO] [MC-Client-dev.lifecycle-1] [c.h.w.s.MCClientManager]: MC Client for cluster dev shut down.
```