### PR TITLE
Cleanup Dockerfile and vulnerability scan

### DIFF
--- a/.github/workflows/publish_latest_snapshot.yml
+++ b/.github/workflows/publish_latest_snapshot.yml
@@ -2,15 +2,6 @@ name: Publish latest-snapshot Docker image for Management Center
 
 on:
   workflow_dispatch:
-    inputs:
-      mcVersion:
-        description: 'MC Version'
-        type: string
-        required: true
-      mcRevision:
-        description: 'MC Revision'
-        type: string
-        required: true
 
 jobs:
   publish_latest_snapshot:
@@ -33,20 +24,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Print MC version and revision
-        run: |
-          echo "mcVersion = ${{ inputs.mcVersion }}"
-          echo "mcRevision = ${{ inputs.mcVersion }}"
-
       - name: Build and push docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/s390x
           build-args: |
-            MC_VERSION=${{ inputs.mcVersion }}
-            MC_REVISION=${{ inputs.mcRevision }}
-            MC_INSTALL_ZIP=hazelcast-management-center-latest-snapshot.zip
+            MC_VERSION=latest-snapshot
           tags: hazelcast/management-center:latest-snapshot
           push: true
           cache-from: type=gha

--- a/.github/workflows/vulnerabilities_scan.yml
+++ b/.github/workflows/vulnerabilities_scan.yml
@@ -44,16 +44,14 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.IMAGE_NAME }}
-          json: true
           args: >-
             --file=Dockerfile
             --print-deps
             --exclude-base-image-vulns
             --policy-path=.snyk
 
-      - name: Upload SNYK report
-        uses: actions/upload-artifact@v3
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
         if: ${{ failure() }}
         with:
-          name: SNYK dependency check report
-          path: ${{github.workspace}}/snyk.json
+          sarif_file: snyk.sarif

--- a/.github/workflows/vulnerabilities_scan.yml
+++ b/.github/workflows/vulnerabilities_scan.yml
@@ -48,7 +48,9 @@ jobs:
             --file=Dockerfile
             --print-deps
             --exclude-base-image-vulns
+            --exclude-app-vulns
             --policy-path=.snyk
+            --fail-on=upgradable
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,26 @@
-ARG MC_VERSION=5.2.1
-ARG MC_INSTALL_NAME="hazelcast-management-center-${MC_VERSION}"
-ARG MC_INSTALL_JAR="${MC_INSTALL_NAME}.jar"
-ARG MC_INSTALL_ZIP="${MC_INSTALL_NAME}.zip"
+ARG MC_VERSION=latest-snapshot
 
 FROM alpine:3.17.2 AS builder
 ARG MC_VERSION
-ARG MC_INSTALL_NAME
-ARG MC_INSTALL_JAR
-ARG MC_INSTALL_ZIP
 
 WORKDIR /tmp/build
 
-RUN echo "Installing new APK packages" \
- && apk add --no-cache wget unzip
+RUN echo "Installing new APK packages"\
+ && apk add --no-cache wget tar
 
-# Comment out the following RUN command to build from a local zip artifact
-RUN echo "Downloading Management Center" \
- && wget -O ${MC_INSTALL_ZIP} -q --show-progress --progress=bar:force https://repository.hazelcast.com/download/management-center/${MC_INSTALL_ZIP}
-
-# ...and uncomment the line below
-#COPY ${MC_INSTALL_ZIP} .
-
-RUN unzip ${MC_INSTALL_ZIP} \
- && mv ${MC_INSTALL_NAME}/${MC_INSTALL_JAR} ${MC_INSTALL_JAR} \
- && mv ${MC_INSTALL_NAME}/bin/start.sh start.sh \
- && mv ${MC_INSTALL_NAME}/bin/mc-conf.sh mc-conf.sh \
- && mv ${MC_INSTALL_NAME}/bin/hz-mc hz-mc
+RUN echo "Downloading Management Center"\
+ && wget -q --show-progress --progress=bar:force\
+ https://repository.hazelcast.com/download/management-center/hazelcast-management-center-${MC_VERSION}.tar.gz -O -\
+ | tar --extract --ungzip --wildcards --no-anchored --strip-components 1\
+ '*/bin/start.sh' '*/bin/mc-conf.sh' '*/bin/hz-mc' '*/hazelcast-management-center-*.jar'
 
 FROM redhat/ubi8-minimal:8.7-1049
 ARG MC_VERSION
-ARG MC_INSTALL_NAME
-ARG MC_INSTALL_JAR
-ARG MC_INSTALL_ZIP
-ARG MC_REVISION=${MC_VERSION}
 
 ENV MC_HOME=/opt/hazelcast/management-center \
     MC_DATA=/data
 
 ENV JAVA_OPTS_DEFAULT="-Dhazelcast.mc.home=${MC_DATA} -Djava.net.preferIPv4Stack=true" \
-    MC_INSTALL_JAR="${MC_INSTALL_JAR}" \
     USER_NAME="hazelcast" \
     USER_UID=10001 \
     MC_HTTP_PORT="8080" \
@@ -67,7 +49,7 @@ LABEL name="hazelcast/management-center-openshift-rhel" \
       io.k8s.display-name="Hazelcast Management Center" \
       io.openshift.expose-services="8080:http,8081:health_check,8443:https" \
       io.openshift.tags="hazelcast,java17,kubernetes,rhel8" \
-      hazelcast.mc.revision="${MC_REVISION}" \
+      hazelcast.mc.revision="${MC_VERSION}" \
       org.opencontainers.image.authors="Hazelcast, Inc. Management Center Team <info@hazelcast.com>"
 
 # Add licenses
@@ -87,10 +69,8 @@ RUN echo "Installing new packages" \
 
 WORKDIR ${MC_HOME}
 
-COPY --from=builder /tmp/build/${MC_INSTALL_JAR} .
-COPY --from=builder --chmod=755 /tmp/build/start.sh ./bin/start.sh
-COPY --from=builder --chmod=755 /tmp/build/mc-conf.sh ./bin/mc-conf.sh
-COPY --from=builder --chmod=755 /tmp/build/hz-mc ./bin/hz-mc
+COPY --from=builder /tmp/build/*.jar .
+COPY --from=builder --chmod=755 /tmp/build/bin/* ./bin/
 COPY --chmod=755 files/mc-start.sh ./bin/mc-start.sh
 
 VOLUME ["${MC_DATA}"]
@@ -99,10 +79,8 @@ EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}
 RUN echo "Adding non-root user" \
  && adduser --uid $USER_UID --system --home $MC_HOME --shell /sbin/nologin $USER_NAME \
  && chown -R $USER_UID:0 $MC_HOME ${MC_DATA} \
- && chmod -R g=u "$MC_HOME" ${MC_DATA} \
- && chmod -R +r $MC_HOME ${MC_DATA} \
- && echo "Setting mc-start.sh permissions" \
- && chmod +x ./bin/mc-start.sh
+ && chmod -R g=u $MC_HOME ${MC_DATA} \
+ && chmod -R +r $MC_HOME ${MC_DATA}
 
 # Switch to hazelcast user
 USER ${USER_UID}


### PR DESCRIPTION
Reduce the number of layers for MC image.
Remove redundant chmod calls in Dockerfile.
Exclude app vulnerabilities from scan.
Report found vulnerabilities to Code scanning in GitHub.