### PR TITLE
Upgrade base image and java version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,16 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Docker repo
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
-        with:
-          version: v0.8.2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish_latest_snapshot.yml
+++ b/.github/workflows/publish_latest_snapshot.yml
@@ -5,18 +5,16 @@ on:
 
 jobs:
   publish_latest_snapshot:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Docker repo
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
-        with:
-          version: v0.8.2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -21,12 +21,10 @@ jobs:
         run: echo ${{ env.RELEASE_VERSION }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
-        with:
-          version: v0.8.2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       SCAN_REGISTRY: "quay.io"
       TIMEOUT_IN_MINS: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps: 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,12 +30,10 @@ jobs:
         run: echo ${{ env.RELEASE_VERSION }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
-        with:
-          version: v0.8.2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to ${{ env.SCAN_REGISTRY }}
         uses: docker/login-action@v3

--- a/.github/workflows/vulnerabilities_scan.yml
+++ b/.github/workflows/vulnerabilities_scan.yml
@@ -21,13 +21,13 @@ jobs:
     name: Scan docker image
     env:
       IMAGE_NAME: hazelcast/management-center:${{ github.sha }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Build
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 ARG MC_VERSION=5.3.3
 ARG MC_DOWNLOAD_BASE_PATH=https://repository.hazelcast.com/download/management-center
 
@@ -15,7 +16,7 @@ RUN echo "Downloading Management Center"\
  && unzip mc.zip\
  && rm -f mc.zip
 
-FROM redhat/ubi8-minimal:8.9-1029
+FROM redhat/ubi9-minimal:9.3
 ARG MC_VERSION
 
 ENV MC_HOME=/opt/hazelcast/management-center \
@@ -49,35 +50,35 @@ LABEL name="hazelcast/management-center-openshift-rhel" \
       io.k8s.description="Starts Management Center web application dedicated to monitor and manage Hazelcast nodes" \
       io.k8s.display-name="Hazelcast Management Center" \
       io.openshift.expose-services="8080:http,8081:health_check,8443:https" \
-      io.openshift.tags="hazelcast,java17,kubernetes,rhel8" \
+      io.openshift.tags="hazelcast,java21,kubernetes,rhel8" \
       hazelcast.mc.revision="${MC_VERSION}" \
       org.opencontainers.image.authors="Hazelcast, Inc. Management Center Team <info@hazelcast.com>"
 
 # Add licenses
-COPY files/licenses /licenses
+COPY --link files/licenses /licenses
 
 ### Atomic Help File
-COPY files/help.1 /help.1
+COPY --link files/help.1 /help.1
 
 RUN echo "Installing new packages" \
  && microdnf upgrade --nodocs \
- && microdnf -y --nodocs install java-17-openjdk \
+ && microdnf -y --nodocs install java-21-openjdk \
  && rm -rf /var/cache/microdnf \
  && microdnf -y clean all \
  && mkdir -p ${MC_HOME} ${MC_DATA} \
  && echo "Granting full access to ${MC_HOME} and ${MC_DATA} to allow running container as non-root with \"docker run --user\" option" \
  && chmod a+rwx ${MC_HOME} ${MC_DATA} \
  && echo "Adding non-root user" \
- && adduser --uid $USER_UID --system --home $MC_HOME --shell /sbin/nologin $USER_NAME \
- && chown -R $USER_UID:0 $MC_HOME ${MC_DATA} \
- && chmod -R g=u $MC_HOME ${MC_DATA} \
- && chmod -R +r $MC_HOME ${MC_DATA}
+ && adduser --uid ${USER_UID} --system --home ${MC_HOME} --shell /sbin/nologin ${USER_NAME} \
+ && chown -R ${USER_UID}:0 ${MC_HOME} ${MC_DATA} \
+ && chmod -R g=u ${MC_HOME} ${MC_DATA} \
+ && chmod -R +r ${MC_HOME} ${MC_DATA}
 
 WORKDIR ${MC_HOME}
 
-COPY --from=builder --chown=$USER_UID:0 /tmp/build/hazelcast-management-center-*/*.jar .
-COPY --from=builder --chmod=775 --chown=$USER_UID:0 /tmp/build/hazelcast-management-center-*/bin/mc-conf.sh /tmp/build/hazelcast-management-center-*/bin/hz-mc /tmp/build/hazelcast-management-center-*/bin/hz-mc ./bin/
-COPY --chmod=775 --chown=$USER_UID:0 files/mc-start.sh ./bin/mc-start.sh
+COPY --link --from=builder --chown=$USER_UID:0 /tmp/build/hazelcast-management-center-*/*.jar .
+COPY --link --from=builder --chmod=775 --chown=$USER_UID:0 /tmp/build/hazelcast-management-center-*/bin/mc-conf.sh /tmp/build/hazelcast-management-center-*/bin/hz-mc /tmp/build/hazelcast-management-center-*/bin/hz-mc ./bin/
+COPY --link --chmod=775 --chown=$USER_UID:0 files/mc-start.sh ./bin/mc-start.sh
 
 VOLUME ["${MC_DATA}"]
 EXPOSE ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_HEALTH_CHECK_PORT}


### PR DESCRIPTION
Use --link for all COPY instructions. See https://www.docker.com/blog/image-rebase-and-improved-remote-cache-support-in-new-buildkit/