### PR TITLE
Add -y for microdnf upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Docker repo

--- a/.github/workflows/publish_latest_snapshot.yml
+++ b/.github/workflows/publish_latest_snapshot.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   publish_latest_snapshot:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Docker repo

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash

--- a/.github/workflows/vulnerabilities_scan.yml
+++ b/.github/workflows/vulnerabilities_scan.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   scan:
+    timeout-minutes: 10
     name: Scan docker image
     env:
       IMAGE_NAME: hazelcast/management-center:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,18 +60,18 @@ COPY --link files/licenses /licenses
 ### Atomic Help File
 COPY --link files/help.1 /help.1
 
-RUN echo "Installing new packages" \
- && microdnf upgrade --nodocs \
- && microdnf -y --nodocs install java-21-openjdk \
- && rm -rf /var/cache/microdnf \
- && microdnf -y clean all \
- && mkdir -p ${MC_HOME} ${MC_DATA} \
- && echo "Granting full access to ${MC_HOME} and ${MC_DATA} to allow running container as non-root with \"docker run --user\" option" \
- && chmod a+rwx ${MC_HOME} ${MC_DATA} \
- && echo "Adding non-root user" \
- && adduser --uid ${USER_UID} --system --home ${MC_HOME} --shell /sbin/nologin ${USER_NAME} \
- && chown -R ${USER_UID}:0 ${MC_HOME} ${MC_DATA} \
- && chmod -R g=u ${MC_HOME} ${MC_DATA} \
+RUN echo "Installing new packages"\
+ && microdnf -y --nodocs upgrade\
+ && microdnf -y --nodocs install java-21-openjdk\
+ && rm -rf /var/cache/microdnf\
+ && microdnf -y clean all\
+ && mkdir -p ${MC_HOME} ${MC_DATA}\
+ && echo "Granting full access to ${MC_HOME} and ${MC_DATA} to allow running container as non-root with \"docker run --user\" option"\
+ && chmod a+rwx ${MC_HOME} ${MC_DATA}\
+ && echo "Adding non-root user"\
+ && adduser --uid ${USER_UID} --system --home ${MC_HOME} --shell /sbin/nologin ${USER_NAME}\
+ && chown -R ${USER_UID}:0 ${MC_HOME} ${MC_DATA}\
+ && chmod -R g=u ${MC_HOME} ${MC_DATA}\
  && chmod -R +r ${MC_HOME} ${MC_DATA}
 
 WORKDIR ${MC_HOME}


### PR DESCRIPTION
Set 10 minute timeout for docker builds to avoid situations like https://github.com/hazelcast/management-center-docker/actions/runs/7455756686
(6 hours default timeout)