### PR TITLE
Remove gha caching for docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,3 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/s390x
           tags: hazelcast/management-center:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -39,5 +39,3 @@ jobs:
           tags: hazelcast/management-center:${{ inputs.MC_VERSION }}
           provenance: false
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -66,8 +66,6 @@ jobs:
           tags: ${{ env.TAGS }}
           provenance: false
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Update Docker Hub Description of Management Center image
         if: env.PUSH_LATEST == 'yes'

--- a/.github/workflows/tag_image_push_rhel.yml
+++ b/.github/workflows/tag_image_push_rhel.yml
@@ -52,8 +52,6 @@ jobs:
           tags: ${{ env.RHEL_IMAGE_TAG }}
           push: true
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Install preflight tool
         run: |

--- a/.github/workflows/vulnerabilities_scan.yml
+++ b/.github/workflows/vulnerabilities_scan.yml
@@ -36,8 +36,6 @@ jobs:
           context: .
           tags: ${{ env.IMAGE_NAME }}
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Scan image by Snyk
         uses: snyk/actions/docker@master


### PR DESCRIPTION
Remove gha caching for docker image build steps

Export to GHA cache takes longer than cached steps duration.
With cache ~3min, without ~2min