### PR TITLE
Automate Docker Packaging tagging

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -28,7 +28,7 @@ jobs:
           git commit --all -m ${{ inputs.new_version }}
           git push
 
-      - name: Create a tag that prefixes the new version with a v (for e.g. v5.1.4 for the 5.1.4 version)
+      - name: Create tag
         run: |
           git tag v${{ inputs.new_version }}
           git push origin v${{ inputs.new_version }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update the first line of the Dockerfile with the new version
+      - name: Update the Dockerfile with the new version
         run: |
           sed --in-place 's/^ARG MC_VERSION=.*/ARG MC_VERSION=${{ inputs.new_version }}/' Dockerfile
 

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,34 @@
+name: Create tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        type: string
+        description: 'The new version number (e.g. `5.5.2`)'
+        required: true
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update the first line of the Dockerfile with the new version
+        run: |
+          sed --in-place 's/^ARG MC_VERSION=.*/ARG MC_VERSION=${{ inputs.new_version }}/' Dockerfile
+
+      - name: Configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Commit and push changes
+        run: |
+          git commit --all -m ${{ inputs.new_version }}
+          git push
+
+      - name: Create a tag that prefixes the new version with a v (for e.g. v5.1.4 for the 5.1.4 version)
+        run: |
+          git tag v${{ inputs.new_version }}
+          git push origin v${{ inputs.new_version }}


### PR DESCRIPTION
Combines the steps listed in https://hazelcast.atlassian.net/wiki/spaces/MC/pages/3478585520/Management+Center+Release+Process#Releasing-the-Docker-Image into a single action.

[Example execution](https://github.com/JackPGreen/management-center-docker/actions/runs/13410224212) making a [dummy `5.7.2` tag](https://github.com/JackPGreen/management-center-docker/releases/tag/v5.7.2).

Post-merge action:
- [ ] update [the docs](https://hazelcast.atlassian.net/wiki/spaces/MC/pages/3478585520/Management+Center+Release+Process#Releasing-the-Docker-Image)
- [ ] delete [fork repo](https://github.com/JackPGreen/management-center-docker)