### PR TITLE
Ensure new `tag-branch` workflow triggers downstream actions

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   create_tag:
     runs-on: ubuntu-latest
+    env:
+      # Workaround to ensure downstrem actions are triggeered by new tags
+      # https://github.com/orgs/community/discussions/27028
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
[In GitHub Actions, workflows are not triggered by actions arising from the default token so an explicit token needs to be provided to achieve this](https://github.com/orgs/community/discussions/27028).

Without this, when tags are pushed via the actions, no builds are triggered to rebuild the packages.

This fix and the original change _cannot be tested_ until we next use them for a release.