### PR TITLE
Remove top-level `env` from GitHub composite actions

### DIFF
--- a/.github/actions/vulnerabilities-scan-image-builder/action.yml
+++ b/.github/actions/vulnerabilities-scan-image-builder/action.yml
@@ -4,16 +4,11 @@ inputs:
   image-name:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: bash
-
 runs:
   using: composite
   steps:
     - name: Generate a dummy MC ZIP
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         #  Avoid scanning Java dependencies, as managed upstream
         zip -r files/hazelcast-management-center.zip $(mktemp -d)


### PR DESCRIPTION
tl;dr - it doesn't work

In composite actions, a `shell` _must_ be specified. To avoid duplication, this was centralised to an `env` variable.

However, GitHub [doesn't support this](https://github.com/orgs/community/discussions/51280) - for example, in [this job](https://github.com/hazelcast/hazelcast-go-client/actions/runs/15848149662/job/44674983175) the output of `${{ env.shell }}` is blank.

It _appeared_ to work because if the specified `shell` is empty, it uses the default shell of the executing runner - and all of our executions were setting `bash` on Linux/Mac or `pwsh` on Windows anyway so the net effect is the same.

This bug appeared when a `bash` composite action failed to resolve `bash` commands on a Windows runner - because it was actually running in an (implicit) `pwsh` shell.